### PR TITLE
Example of creating the parquet file with map group type.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .project
 .classpath
 .settings/*
+.idea/
 *.swp
 target/*
 .README.md.html

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ for the Parquet logical types.
 Note that poking around in Drill suggests that Drill has very poor support for Parquet logical types. Some times
 cause an error, the DATE type causes very bizarre output.
 
-The syntax allows structured types (though I've not tried this yet):
+The syntax allows structured types:
 
     message structured {
       required int32 index;
@@ -43,7 +43,18 @@ The syntax allows structured types (though I've not tried this yet):
         optional int32 first;
         optional int32 second;
       }
-    }   
+    }
+
+and outdated annotations (See [Lists](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#backward-compatibility-rules)    and [Maps](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#backward-compatibility-rules-1) "Backward-compatibility rules"):
+
+    message nested_map {
+      optional group map_field (MAP) {
+        repeated group map (MAP_KEY_VALUE) {
+          required binary key (UTF8);
+          required int64 value;
+        }
+      }
+    }
 
 ## File Builder
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <parquet.version>1.8.1</parquet.version>
+    <parquet.version>1.9.0</parquet.version>
   </properties>
 
   <build>

--- a/src/main/java/org/apache/drill/parquet_builder/Main.java
+++ b/src/main/java/org/apache/drill/parquet_builder/Main.java
@@ -16,10 +16,11 @@ public class Main
     }
 
     private void run() throws IOException {
-      File destDir = new File( "/Users/progers/play/data" );
+      File destDir = new File( "/tmp/play/data" );
       BuildFilesDirect builder = new BuildFilesDirect( destDir );
       builder.buildInt32Uint8( );
       builder.buildInt32Uint16( );
       builder.buildInt32Uint32( );
+      builder.buildOptionalMapRequiredBinaryRequiredInt64( );
     }
 }

--- a/src/test/java/org/apache/drill/parquet_builder/AppTest.java
+++ b/src/test/java/org/apache/drill/parquet_builder/AppTest.java
@@ -7,8 +7,7 @@ import junit.framework.TestSuite;
 /**
  * Unit test for simple App.
  */
-public class AppTest 
-    extends TestCase
+public class AppTest extends TestCase
 {
     /**
      * Create the test case


### PR DESCRIPTION
Paul,

I have added an example of creating the parquet file with map group type.
I have used it for DRILL-5970. Please add it for your repository, if you find it useful.